### PR TITLE
fix issue #1 stack level too deep

### DIFF
--- a/autorspec
+++ b/autorspec
@@ -3,10 +3,10 @@
 class AutoRspec
   def initialize
     @files = nil
-    loop
+    start
   end
 
-  def loop
+  def start
     loop do
       run if timestamps_changed?
       sleep 1


### PR DESCRIPTION
`loop()` method overwrites Ruby `loop`. Renamed it.